### PR TITLE
Create charts

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+API_KEY="TEST_API_KEY"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 rvm: 2.3.1
 cache: bundler
 sudo: false
+env:
+  - API_KEY="TEST_API_KEY"
 before_install:
   - "echo '--colour' > ~/.rspec"
   - git config --global user.name 'Travis CI'

--- a/lastfm.gemspec
+++ b/lastfm.gemspec
@@ -28,7 +28,12 @@ listening to over an "unusual" time period.
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.version = Lastfm::VERSION
 
+  s.add_dependency "dotenv"
+  s.add_dependency "faraday"
+  s.add_dependency "faraday_middleware"
   s.add_dependency 'rake'
 
   s.add_development_dependency 'rspec', '~> 3.2'
+  s.add_development_dependency "vcr"
+  s.add_development_dependency "webmock"
 end

--- a/lib/lastfm.rb
+++ b/lib/lastfm.rb
@@ -1,1 +1,17 @@
+# frozen_string_literal: true
+require "dotenv"
+require "faraday"
+require "faraday_middleware"
+
+require "lastfm/adapter"
+require "lastfm/artist"
+require "lastfm/chart"
+require "lastfm/connection"
+require "lastfm/entry"
+require "lastfm/query"
+require "lastfm/recent_tracks"
+require "lastfm/track"
+require "lastfm/tracks"
 require "lastfm/version"
+
+Dotenv.load

--- a/lib/lastfm/adapter.rb
+++ b/lib/lastfm/adapter.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+module Lastfm
+  class Adapter
+    def initialize(data)
+      @data = data
+    end
+
+    def total_pages
+      attributes.fetch("totalPages").to_i
+    end
+
+    def tracks
+      track.map { |track_data| Track.new(track_data) }
+    end
+
+    private
+
+    attr_reader :data
+
+    def attributes
+      recent_tracks.fetch("@attr")
+    end
+
+    def recent_tracks
+      data.fetch("recenttracks")
+    end
+
+    def track
+      recent_tracks.fetch("track")
+    end
+  end
+end

--- a/lib/lastfm/artist.rb
+++ b/lib/lastfm/artist.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module Lastfm
+  class Artist
+    def initialize(data)
+      @data = data
+    end
+
+    def name
+      data.fetch("#text")
+    end
+
+    private
+
+    attr_reader :data
+  end
+end

--- a/lib/lastfm/chart.rb
+++ b/lib/lastfm/chart.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+module Lastfm
+  class Chart
+    def initialize(from:, to:, user:)
+      @from = from
+      @to = to
+      @user = user
+    end
+
+    def get
+      recent_tracks.to_chart
+    end
+
+    private
+
+    attr_reader :from, :to, :user
+
+    def adapted_response
+      @_adapted_response ||= connection.get
+    end
+
+    def adapter
+      Adapter
+    end
+
+    def connection(page_number = 1)
+      Connection.new(adapter: adapter, page_number: page_number, query: query)
+    end
+
+    def first_page
+      adapted_response
+    end
+
+    def other_pages
+      (2..total_pages).map { |page_number| connection(page_number).get }
+    end
+
+    def pages
+      [first_page, other_pages].flatten
+    end
+
+    def query
+      @_query ||= Query.new(from: from, to: to, user: user)
+    end
+
+    def recent_tracks
+      RecentTracks.new(pages)
+    end
+
+    def total_pages
+      first_page.total_pages
+    end
+  end
+end

--- a/lib/lastfm/connection.rb
+++ b/lib/lastfm/connection.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+module Lastfm
+  class Connection
+    def initialize(adapter:, page_number: 1, query:)
+      @adapter = adapter
+      @page_number = page_number
+      @query = query
+    end
+
+    def get
+      adapter.new(response_body)
+    end
+
+    private
+
+    attr_reader :adapter, :page_number, :query
+
+    def connection
+      Faraday.new(url: "http://ws.audioscrobbler.com") do |faraday|
+        faraday.response :json
+        faraday.adapter Faraday.default_adapter
+      end
+    end
+
+    def from
+      query.from
+    end
+
+    def response
+      connection.get(
+        "/2.0/",
+        api_key: ENV["API_KEY"],
+        format: "json",
+        from: from,
+        limit: 200,
+        method: "user.getrecenttracks",
+        page: page_number,
+        to: to,
+        user: user,
+      )
+    end
+
+    def response_body
+      response.body
+    end
+
+    def to
+      query.to
+    end
+
+    def user
+      query.user
+    end
+  end
+end

--- a/lib/lastfm/entry.rb
+++ b/lib/lastfm/entry.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+module Lastfm
+  class Entry
+    attr_reader :play_count
+
+    def initialize(play_count:, track:)
+      @play_count = play_count
+      @track = track
+    end
+
+    def artist_name
+      track.artist_name
+    end
+
+    def track_name
+      track.name
+    end
+
+    private
+
+    attr_reader :track
+  end
+end

--- a/lib/lastfm/query.rb
+++ b/lib/lastfm/query.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+module Lastfm
+  class Query
+    attr_reader :user
+
+    def initialize(from:, to:, user:)
+      @from = from
+      @to = to
+      @user = user
+    end
+
+    def from
+      @from.to_i
+    end
+
+    def to
+      @to.to_i
+    end
+  end
+end

--- a/lib/lastfm/recent_tracks.rb
+++ b/lib/lastfm/recent_tracks.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+module Lastfm
+  class RecentTracks
+    def initialize(pages)
+      @pages = pages
+    end
+
+    def to_chart
+      tracks.to_chart
+    end
+
+    private
+
+    attr_reader :pages
+
+    def tracks
+      Tracks.new(pages.flat_map(&:tracks))
+    end
+
+    def tracks_data
+      pages.flat_map { |page| page.fetch("recenttracks").fetch("track") }
+    end
+  end
+end

--- a/lib/lastfm/track.rb
+++ b/lib/lastfm/track.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+module Lastfm
+  class Track
+    def initialize(data)
+      @data = data
+    end
+
+    def artist_name
+      artist.name
+    end
+
+    def eql?(other)
+      self == other
+    end
+
+    def hash
+      [artist_name, name].hash
+    end
+
+    def name
+      data.fetch("name")
+    end
+
+    def ==(other)
+      other.artist_name == artist_name && other.name == name
+    end
+
+    private
+
+    attr_reader :data
+
+    def artist
+      Artist.new(artist_data)
+    end
+
+    def artist_data
+      data.fetch("artist")
+    end
+  end
+end

--- a/lib/lastfm/tracks.rb
+++ b/lib/lastfm/tracks.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+module Lastfm
+  class Tracks
+    def initialize(tracks)
+      @tracks = tracks
+    end
+
+    def to_chart
+      entries.sort_by(&:play_count).reverse
+    end
+
+    private
+
+    attr_reader :tracks
+
+    def entries
+      play_counts.map do |track, play_count|
+        Entry.new(play_count: play_count, track: track)
+      end
+    end
+
+    def play_counts
+      tracks.each_with_object(Hash.new(0)) do |track, play_counts|
+        play_counts[track] += 1
+      end
+    end
+  end
+end

--- a/spec/features/get_top_tracks_spec.rb
+++ b/spec/features/get_top_tracks_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+RSpec.describe "Get Top Tracks" do
+  context "when there are no recent tracks" do
+    it "is empty" do
+      VCR.use_cassette("recent_tracks/none") do
+        chart = Lastfm::Chart.new(
+          from: Time.at(1_479_316_791),
+          to: Time.at(1_479_316_791),
+          user: "TEST_USER",
+        )
+
+        expect(chart.get).to be_empty
+      end
+    end
+  end
+
+  context "when there is one track" do
+    it "lists the entry" do
+      VCR.use_cassette("recent_tracks/one") do
+        chart = Lastfm::Chart.new(
+          from: Time.at(1_479_316_791),
+          to: Time.at(1_479_316_791),
+          user: "TEST_USER",
+        )
+        entries = chart.get
+        entry = entries.first
+
+        expect(entries.count).to eq 1
+        expect(entry.track_name).to eq "TEST_TRACK"
+        expect(entry.artist_name).to eq "TEST_ARTIST"
+        expect(entry.play_count).to eq 1
+      end
+    end
+  end
+
+  context "when the same track appears multiple times" do
+    it "lists one entry with the correct play count" do
+      VCR.use_cassette("recent_tracks/same") do
+        chart = Lastfm::Chart.new(
+          from: Time.at(1_479_316_791),
+          to: Time.at(1_479_316_791),
+          user: "TEST_USER",
+        )
+        entries = chart.get
+        entry = entries.first
+
+        expect(entries.count).to eq 1
+        expect(entry.track_name).to eq "TEST_TRACK"
+        expect(entry.artist_name).to eq "TEST_ARTIST"
+        expect(entry.play_count).to eq 2
+      end
+    end
+  end
+
+  context "when there are multiple tracks" do
+    it "lists the entries in play count order" do
+      VCR.use_cassette("recent_tracks/multiple") do
+        chart = Lastfm::Chart.new(
+          from: Time.at(1_479_316_791),
+          to: Time.at(1_479_316_791),
+          user: "TEST_USER",
+        )
+        entries = chart.get
+
+        expect(entries.count).to eq 2
+        [
+          ["TEST_ARTIST_1", 2, "TEST_TRACK_1"],
+          ["TEST_ARTIST_2", 1, "TEST_TRACK_2"],
+        ].each_with_index do |(artist_name, play_count, track_name), index|
+          expect(entries[index].artist_name).to eq artist_name
+          expect(entries[index].play_count).to eq play_count
+          expect(entries[index].track_name).to eq track_name
+        end
+      end
+    end
+  end
+
+  context "when there are multiple pages" do
+    it "lists the entries in play count order" do
+      VCR.use_cassette("recent_tracks/page_1") do
+        VCR.use_cassette("recent_tracks/page_2") do
+          chart = Lastfm::Chart.new(
+            from: Time.at(1_479_316_791),
+            to: Time.at(1_479_316_791),
+            user: "TEST_USER",
+          )
+          entries = chart.get
+
+          expect(entries.count).to eq 2
+          [
+            ["TEST_ARTIST_1", 2, "TEST_TRACK_1"],
+            ["TEST_ARTIST_2", 1, "TEST_TRACK_2"],
+          ].each_with_index do |(artist_name, play_count, track_name), index|
+            expect(entries[index].artist_name).to eq artist_name
+            expect(entries[index].play_count).to eq play_count
+            expect(entries[index].track_name).to eq track_name
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lastfm/adapter_spec.rb
+++ b/spec/lastfm/adapter_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Lastfm
+  RSpec.describe Adapter do
+    describe "#total_pages" do
+      it "returns the total number of pages" do
+        total_pages = "0"
+        data = {
+          "recenttracks" => { "@attr" => { "totalPages" => total_pages } },
+        }
+
+        expect(Adapter.new(data).total_pages).to eq total_pages.to_i
+      end
+    end
+
+    describe "#tracks" do
+      it "is a list of adapted tracks" do
+        artist_name = "TEST_ARTIST"
+        track_name = "TEST_TRACK"
+        data = {
+          "recenttracks" => {
+            "track" => [
+              { "artist" => { "#text" => artist_name }, "name" => track_name },
+            ],
+          },
+        }
+
+        tracks = Adapter.new(data).tracks
+        track = tracks.first
+
+        expect(tracks.count).to eq 1
+        expect(track.artist_name).to eq artist_name
+        expect(track.name).to eq track_name
+      end
+    end
+  end
+end

--- a/spec/lastfm/artist_spec.rb
+++ b/spec/lastfm/artist_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Lastfm
+  RSpec.describe Artist do
+    describe "#name" do
+      it "is 'TEST_ARTIST'" do
+        name = "TEST_ARTIST"
+
+        expect(Artist.new("#text" => name).name).to eq name
+      end
+    end
+  end
+end

--- a/spec/lastfm/chart_spec.rb
+++ b/spec/lastfm/chart_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Lastfm
+  RSpec.describe Chart do
+    describe "#get" do
+      it "the recent tracks as a chart" do
+        chart = []
+        from = Time.now
+        response_1 = instance_double("Adapter", total_pages: 2)
+        connection_1 = instance_double("Connection", get: response_1)
+        response_2 = instance_double("Adapter", total_pages: 2)
+        connection_2 = instance_double("Connection", get: response_2)
+        query = instance_double("Query")
+        recent_tracks = instance_double("RecentTracks", to_chart: chart)
+        to = Time.now
+        user = "TEST_USER"
+        allow(Connection).to receive(:new).once.with(
+          adapter: Adapter,
+          page_number: 1,
+          query: query,
+        ).and_return(connection_1)
+        allow(Connection).to receive(:new).once.with(
+          adapter: Adapter,
+          page_number: 2,
+          query: query,
+        ).and_return(connection_2)
+        allow(Query).to receive(:new).once.with(from: from, to: to, user: user).
+          and_return(query)
+        allow(RecentTracks).to receive(:new).once.with(
+          [
+            response_1,
+            response_2,
+          ],
+        ).and_return(recent_tracks)
+
+        expect(Chart.new(from: from, to: to, user: user).get).to eq chart
+      end
+    end
+  end
+end

--- a/spec/lastfm/connection_spec.rb
+++ b/spec/lastfm/connection_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Lastfm
+  RSpec.describe Connection do
+    describe "#get" do
+      it "is the response body" do
+        VCR.use_cassette("recent_tracks/none") do
+          adapted_response = instance_double("Adapter")
+          adapter = class_double("Adapter")
+          from = Time.at(1_479_316_791).to_i
+          to = Time.at(1_479_316_791).to_i
+          user = "TEST_USER"
+          body = {
+            "recenttracks" => {
+              "@attr" => {
+                "page" => "1",
+                "perPage" => "1",
+                "total" => "0",
+                "totalPages" => "0",
+                "user" => user,
+              },
+              "track" => [],
+            },
+          }
+          query = instance_double("Query", from: from, to: to, user: user)
+          allow(adapter).to receive(:new).once.with(body).
+            and_return(adapted_response)
+          connection = Connection.new(adapter: adapter, query: query)
+
+          expect(connection.get).to eq adapted_response
+        end
+      end
+    end
+  end
+end

--- a/spec/lastfm/entry_spec.rb
+++ b/spec/lastfm/entry_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Lastfm
+  RSpec.describe Entry do
+    describe "#artist_name" do
+      it "is the name of the initialized track's artist" do
+        artist_name = "TEST_ARTIST"
+        track = instance_double("Track", artist_name: artist_name)
+        entry = Entry.new(play_count: 1, track: track)
+
+        expect(entry.artist_name).to eq artist_name
+      end
+    end
+
+    describe "#play_count" do
+      it "is the initialized play count" do
+        play_count = 1
+        track = instance_double("Track")
+        entry = Entry.new(play_count: play_count, track: track)
+
+        expect(entry.play_count).to eq play_count
+      end
+    end
+
+    describe "#track_name" do
+      it "is the name of the initialized track's" do
+        track_name = "TEST_TRACK"
+        track = instance_double("Track", name: track_name)
+        entry = Entry.new(play_count: 1, track: track)
+
+        expect(entry.track_name).to eq track_name
+      end
+    end
+  end
+end

--- a/spec/lastfm/query_spec.rb
+++ b/spec/lastfm/query_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Lastfm
+  RSpec.describe Query do
+    describe "#from" do
+      it "is the initialized from time as a timestamp" do
+        from = Time.now
+        to = Time.now
+        user = "TEST_USER"
+
+        expect(Query.new(from: from, to: to, user: user).from).to eq from.to_i
+      end
+    end
+
+    describe "#to" do
+      it "is the initialized to time as a timestamp" do
+        from = Time.now
+        to = Time.now
+        user = "TEST_USER"
+
+        expect(Query.new(from: from, to: to, user: user).to).to eq to.to_i
+      end
+    end
+
+    describe "#user" do
+      it "is the initialized user" do
+        from = Time.now
+        to = Time.now
+        user = "TEST_USER"
+
+        expect(Query.new(from: from, to: to, user: user).user).to eq user
+      end
+    end
+  end
+end

--- a/spec/lastfm/recent_tracks_spec.rb
+++ b/spec/lastfm/recent_tracks_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Lastfm
+  RSpec.describe RecentTracks do
+    describe "#to_chart" do
+      it "is the tracks converted to a chart" do
+        chart = []
+        tracks_data = []
+        data = instance_double("Adapter", tracks: tracks_data)
+        tracks = instance_double("Tracks", to_chart: chart)
+        allow(Tracks).to receive(:new).once.with(tracks_data).and_return(tracks)
+
+        expect(RecentTracks.new([data]).to_chart).to eq chart
+      end
+    end
+  end
+end

--- a/spec/lastfm/track_spec.rb
+++ b/spec/lastfm/track_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Lastfm
+  RSpec.describe Track do
+    describe "#artist_name" do
+      it "is 'TEST_ARTIST'" do
+        artist_name = "TEST_ARTIST"
+        artist_data = { "#text" => artist_name }
+        artist = instance_double("Artist", name: artist_name)
+        data = { "artist" => artist_data }
+        allow(Artist).to receive(:new).once.with(artist_data).and_return(artist)
+
+        expect(Track.new(data).artist_name).to eq artist_name
+      end
+    end
+
+    describe "#eql?" do
+      context "when the tracks have the same artist and name" do
+        it "is equal" do
+          data = {
+            "artist" => { "#text" => "TEST_ARTIST" },
+            "name" => "TEST_TRACK",
+          }
+
+          expect(Track.new(data)).to eql Track.new(data)
+        end
+      end
+
+      context "when the tracks have different data" do
+        it "is not equal" do
+          data = {
+            "artist" => { "#text" => "TEST_ARTIST" },
+            "name" => "TEST_TRACK",
+          }
+          different_track = Track.new(data.merge("name" => "OTHER_TRACK"))
+
+          expect(Track.new(data)).to_not eql different_track
+        end
+      end
+    end
+
+    describe "#hash" do
+      it "is the hash of the array of artist and track" do
+        artist_name = "TEST_ARTIST"
+        track_name = "TEST_TRACK"
+        data = {
+          "artist" => { "#text" => artist_name },
+          "name" => track_name,
+        }
+
+        expect(Track.new(data).hash).to eq [artist_name, track_name].hash
+      end
+    end
+
+    describe "#name" do
+      it "is the initialized track name" do
+        track_name = "TEST_TRACK"
+        data = { "name" => track_name }
+
+        expect(Track.new(data).name).to eq track_name
+      end
+    end
+
+    describe "#==" do
+      context "when the tracks have the same artist and name" do
+        it "is equal" do
+          data = {
+            "artist" => { "#text" => "TEST_ARTIST" },
+            "name" => "TEST_TRACK",
+          }
+
+          expect(Track.new(data)).to eq Track.new(data)
+        end
+      end
+
+      context "when the tracks have different data" do
+        it "is not equal" do
+          data = {
+            "artist" => { "#text" => "TEST_ARTIST" },
+            "name" => "TEST_TRACK",
+          }
+          different_track = Track.new(data.merge("name" => "OTHER_TRACK"))
+
+          expect(Track.new(data)).to_not eq different_track
+        end
+      end
+    end
+  end
+end

--- a/spec/lastfm/tracks_spec.rb
+++ b/spec/lastfm/tracks_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module Lastfm
+  RSpec.describe Tracks do
+    describe "#to_chart" do
+      it "is all tracks sorted by play count" do
+        artist_name_1 = "TEST_ARTIST_1"
+        artist_name_2 = "TEST_ARTIST_2"
+        track_name_1 = "TEST_TRACK_1"
+        track_name_2 = "TEST_TRACK_2"
+        track_1 = Track.new(
+          "artist" => { "#text" => artist_name_1 },
+          "name" => track_name_1,
+        )
+        track_2 = Track.new(
+          "artist" => { "#text" => artist_name_2 },
+          "name" => track_name_2,
+        )
+        tracks = [track_2, track_1, track_1]
+
+        entries = Tracks.new(tracks).to_chart
+
+        expect(entries.count).to eq 2
+        [
+          [artist_name_1, 2, track_name_1],
+          [artist_name_2, 1, track_name_2],
+        ].each_with_index do |(artist_name, play_count, track_name), index|
+          expect(entries[index].artist_name).to eq artist_name
+          expect(entries[index].play_count).to eq play_count
+          expect(entries[index].track_name).to eq track_name
+        end
+      end
+    end
+  end
+end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+require "vcr"
+
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/support/vcr/cassettes"
+  config.hook_into :webmock
+end

--- a/spec/support/vcr/cassettes/recent_tracks/multiple.yml
+++ b/spec/support/vcr/cassettes/recent_tracks/multiple.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ws.audioscrobbler.com/2.0/?api_key=TEST_API_KEY&format=json&from=1479316791&limit=200&method=user.getrecenttracks&page=1&to=1479316791&user=TEST_USER
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty/1.9.7.3
+      Date:
+      - Wed, 16 Nov 2016 15:06:28 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "recenttracks": {
+            "@attr": {
+              "page": "1",
+              "perPage": "3",
+              "total": "3",
+              "totalPages": "1",
+              "user": "TEST_USER"
+            },
+            "track": [
+              {
+                "artist": { "#text": "TEST_ARTIST_2" },
+                "name": "TEST_TRACK_2"
+              },
+              {
+                "artist": { "#text": "TEST_ARTIST_1" },
+                "name": "TEST_TRACK_1"
+              },
+              {
+                "artist": { "#text": "TEST_ARTIST_1" },
+                "name": "TEST_TRACK_1"
+              }
+            ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 15:06:28 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr/cassettes/recent_tracks/none.yml
+++ b/spec/support/vcr/cassettes/recent_tracks/none.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ws.audioscrobbler.com/2.0/?api_key=TEST_API_KEY&format=json&from=1479316791&limit=200&method=user.getrecenttracks&page=1&to=1479316791&user=TEST_USER
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty/1.9.7.3
+      Date:
+      - Tue, 15 Nov 2016 14:35:05 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '33011'
+      Connection:
+      - keep-alive
+      Access-Control-Request-Headers:
+      - Origin, X-Atmosphere-tracking-id, X-Atmosphere-Framework, X-Cache-Date, Content-Type,
+        X-Atmosphere-Transport, *
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "recenttracks": {
+            "@attr": {
+              "page": "1",
+              "perPage": "1",
+              "total": "0",
+              "totalPages": "0",
+              "user": "TEST_USER"
+            },
+            "track": []
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 15 Nov 2016 14:35:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr/cassettes/recent_tracks/one.yml
+++ b/spec/support/vcr/cassettes/recent_tracks/one.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ws.audioscrobbler.com/2.0/?api_key=TEST_API_KEY&format=json&from=1479316791&limit=200&method=user.getrecenttracks&page=1&to=1479316791&user=TEST_USER
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty/1.9.7.3
+      Date:
+      - Tue, 15 Nov 2016 14:52:54 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "recenttracks": {
+            "@attr": {
+              "page": "1",
+              "perPage": "1",
+              "total": "1",
+              "totalPages": "1",
+              "user": "TEST_USER"
+            },
+            "track": [
+              {
+                "artist": { "#text": "TEST_ARTIST" },
+                "name": "TEST_TRACK"
+              }
+            ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 15 Nov 2016 14:52:55 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr/cassettes/recent_tracks/page_1.yml
+++ b/spec/support/vcr/cassettes/recent_tracks/page_1.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ws.audioscrobbler.com/2.0/?api_key=TEST_API_KEY&format=json&from=1479316791&limit=200&method=user.getrecenttracks&page=1&to=1479316791&user=TEST_USER
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty/1.9.7.3
+      Date:
+      - Wed, 16 Nov 2016 15:23:00 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "recenttracks": {
+            "@attr": {
+              "page": "1",
+              "perPage": "2",
+              "total": "3",
+              "totalPages": "2",
+              "user": "TEST_USER"
+            },
+            "track": [
+              {
+                "artist": { "#text": "TEST_ARTIST_2" },
+                "name": "TEST_TRACK_2"
+              },
+              {
+                "artist": { "#text": "TEST_ARTIST_1" },
+                "name": "TEST_TRACK_1"
+              }
+            ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 15:23:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr/cassettes/recent_tracks/page_2.yml
+++ b/spec/support/vcr/cassettes/recent_tracks/page_2.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ws.audioscrobbler.com/2.0/?api_key=TEST_API_KEY&format=json&from=1479316791&limit=200&method=user.getrecenttracks&page=2&to=1479316791&user=TEST_USER
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty/1.9.7.3
+      Date:
+      - Wed, 16 Nov 2016 15:23:00 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "recenttracks": {
+            "@attr": {
+              "page": "2",
+              "perPage": "2",
+              "total": "3",
+              "totalPages": "2",
+              "user": "TEST_USER"
+            },
+            "track": [
+              {
+                "artist": { "#text": "TEST_ARTIST_1" },
+                "name": "TEST_TRACK_1"
+              }
+            ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 15:23:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr/cassettes/recent_tracks/same.yml
+++ b/spec/support/vcr/cassettes/recent_tracks/same.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ws.audioscrobbler.com/2.0/?api_key=TEST_API_KEY&format=json&from=1479316791&limit=200&method=user.getrecenttracks&page=1&to=1479316791&user=TEST_USER
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty/1.9.7.3
+      Date:
+      - Wed, 16 Nov 2016 14:12:07 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "recenttracks": {
+            "@attr": {
+              "page": "1",
+              "perPage": "2",
+              "total": "2",
+              "totalPages": "1",
+              "user": "TEST_USER"
+            },
+            "track": [
+              {
+                "artist": { "#text": "TEST_ARTIST" },
+                "name": "TEST_TRACK"
+              },
+              {
+                "artist": { "#text": "TEST_ARTIST" },
+                "name": "TEST_TRACK"
+              }
+            ]
+          }
+        }
+    http_version: 
+  recorded_at: Wed, 16 Nov 2016 14:12:08 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Previously, the repository only contained a boilerplate gem, which had no functionality at all. Added `Lastfm::Chart` that takes a time range and a user name to generate a list of most played tracks over that time period.

![](http://i.giphy.com/vgdsngkAmC6Os.gif)