### PR TITLE
Add filtering of duplicate tracks

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+API_KEY="TEST_API_KEY"

--- a/lib/lastfm/track.rb
+++ b/lib/lastfm/track.rb
@@ -9,6 +9,10 @@ module Lastfm
       artist.name
     end
 
+    def date
+      data.fetch("date").fetch("uts")
+    end
+
     def eql?(other)
       self == other
     end

--- a/lib/lastfm/tracks.rb
+++ b/lib/lastfm/tracks.rb
@@ -19,8 +19,12 @@ module Lastfm
       end
     end
 
+    def unique_tracks
+      tracks.uniq { |track| [track.artist_name, track.name, track.date] }
+    end
+
     def play_counts
-      tracks.each_with_object(Hash.new(0)) do |track, play_counts|
+      unique_tracks.each_with_object(Hash.new(0)) do |track, play_counts|
         play_counts[track] += 1
       end
     end

--- a/spec/features/get_top_tracks_spec.rb
+++ b/spec/features/get_top_tracks_spec.rb
@@ -101,4 +101,24 @@ RSpec.describe "Get Top Tracks" do
       end
     end
   end
+
+  context "when there are duplicates of the same track" do
+    it "only shows the track once" do
+      VCR.use_cassette("recent_tracks/duplicate") do
+        chart = Lastfm::Chart.new(
+          from: Time.at(1_479_316_791),
+          to: Time.at(1_479_316_791),
+          user: "TEST_USER",
+        )
+
+        entries = chart.get
+
+        entry = entries.first
+        expect(entries.count).to eq 1
+        expect(entry.track_name).to eq "TEST_TRACK"
+        expect(entry.artist_name).to eq "TEST_ARTIST"
+        expect(entry.play_count).to eq 1
+      end
+    end
+  end
 end

--- a/spec/lastfm/track_spec.rb
+++ b/spec/lastfm/track_spec.rb
@@ -15,6 +15,17 @@ module Lastfm
       end
     end
 
+    describe "#timestamp" do
+      it "is 'TEST_TIME'" do
+        data = { "date" => { "uts" => "TEST_TIME" } }
+        track = Track.new(data)
+
+        date = track.date
+
+        expect(date).to eq "TEST_TIME"
+      end
+    end
+
     describe "#eql?" do
       context "when the tracks have the same artist and name" do
         it "is equal" do

--- a/spec/lastfm/tracks_spec.rb
+++ b/spec/lastfm/tracks_spec.rb
@@ -5,26 +5,26 @@ module Lastfm
   RSpec.describe Tracks do
     describe "#to_chart" do
       it "is all tracks sorted by play count" do
-        artist_name_1 = "TEST_ARTIST_1"
-        artist_name_2 = "TEST_ARTIST_2"
-        track_name_1 = "TEST_TRACK_1"
-        track_name_2 = "TEST_TRACK_2"
-        track_1 = Track.new(
-          "artist" => { "#text" => artist_name_1 },
-          "name" => track_name_1,
+        artist_name1 = "TEST_ARTIST_1"
+        artist_name2 = "TEST_ARTIST_2"
+        track_name1 = "TEST_TRACK_1"
+        track_name2 = "TEST_TRACK_2"
+        track1 = Track.new(
+          "artist" => { "#text" => artist_name1 },
+          "name" => track_name1,
         )
-        track_2 = Track.new(
-          "artist" => { "#text" => artist_name_2 },
-          "name" => track_name_2,
+        track2 = Track.new(
+          "artist" => { "#text" => artist_name2 },
+          "name" => track_name2,
         )
-        tracks = [track_2, track_1, track_1]
+        tracks = [track2, track1, track1]
 
         entries = Tracks.new(tracks).to_chart
 
         expect(entries.count).to eq 2
         [
-          [artist_name_1, 2, track_name_1],
-          [artist_name_2, 1, track_name_2],
+          [artist_name1, 2, track_name1],
+          [artist_name2, 1, track_name2],
         ].each_with_index do |(artist_name, play_count, track_name), index|
           expect(entries[index].artist_name).to eq artist_name
           expect(entries[index].play_count).to eq play_count

--- a/spec/lastfm/tracks_spec.rb
+++ b/spec/lastfm/tracks_spec.rb
@@ -11,10 +11,12 @@ module Lastfm
         track_name2 = "TEST_TRACK_2"
         track1 = Track.new(
           "artist" => { "#text" => artist_name1 },
+          "date" => { "uts" => "TEST_TIME_1" },
           "name" => track_name1,
         )
         track2 = Track.new(
           "artist" => { "#text" => artist_name2 },
+          "date" => { "uts" => "TEST_TIME_1" },
           "name" => track_name2,
         )
         tracks = [track2, track1, track1]

--- a/spec/lastfm/tracks_spec.rb
+++ b/spec/lastfm/tracks_spec.rb
@@ -19,7 +19,12 @@ module Lastfm
           "date" => { "uts" => "TEST_TIME_1" },
           "name" => track_name2,
         )
-        tracks = [track2, track1, track1]
+        track3 = Track.new(
+          "artist" => { "#text" => artist_name1 },
+          "date" => { "uts" => "TEST_TIME_2" },
+          "name" => track_name1,
+        )
+        tracks = [track2, track1, track1, track3]
 
         entries = Tracks.new(tracks).to_chart
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require "bundler/setup"
+require "dotenv/load"
 
+Dotenv.load(".env.test")
 Bundler.require(:default, :test)
 
 require((Pathname.new(__FILE__).dirname + "../lib/lastfm").expand_path)

--- a/spec/support/vcr/cassettes/recent_tracks/duplicate.yml
+++ b/spec/support/vcr/cassettes/recent_tracks/duplicate.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ws.audioscrobbler.com/2.0/?api_key=TEST_API_KEY&format=json&from=1479316791&limit=200&method=user.getrecenttracks&page=1&to=1479316791&user=TEST_USER
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty/1.9.7.3
+      Date:
+      - Tue, 15 Nov 2016 14:52:54 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "recenttracks": {
+            "@attr": {
+              "page": "1",
+              "perPage": "2",
+              "total": "2",
+              "totalPages": "1",
+              "user": "TEST_USER"
+            },
+            "track": [
+              {
+                "artist": { "#text": "TEST_ARTIST" },
+                "date": { "uts": "1_479_316_791" },
+                "name": "TEST_TRACK"
+              },
+              {
+                "artist": { "#text": "TEST_ARTIST" },
+                "date": { "uts": "1_479_316_791" },
+                "name": "TEST_TRACK"
+              }
+            ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 15 Nov 2016 14:52:55 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr/cassettes/recent_tracks/multiple.yml
+++ b/spec/support/vcr/cassettes/recent_tracks/multiple.yml
@@ -49,14 +49,17 @@ http_interactions:
             "track": [
               {
                 "artist": { "#text": "TEST_ARTIST_2" },
+                "date": { "uts": "1_479_316_791" },
                 "name": "TEST_TRACK_2"
               },
               {
                 "artist": { "#text": "TEST_ARTIST_1" },
+                "date": { "uts": "1_479_316_791" },
                 "name": "TEST_TRACK_1"
               },
               {
                 "artist": { "#text": "TEST_ARTIST_1" },
+                "date": { "uts": "1_479_316_792" },
                 "name": "TEST_TRACK_1"
               }
             ]

--- a/spec/support/vcr/cassettes/recent_tracks/page_1.yml
+++ b/spec/support/vcr/cassettes/recent_tracks/page_1.yml
@@ -49,10 +49,12 @@ http_interactions:
             "track": [
               {
                 "artist": { "#text": "TEST_ARTIST_2" },
+                "date": { "uts": "1_479_316_791" },
                 "name": "TEST_TRACK_2"
               },
               {
                 "artist": { "#text": "TEST_ARTIST_1" },
+                "date": { "uts": "1_479_316_791" },
                 "name": "TEST_TRACK_1"
               }
             ]

--- a/spec/support/vcr/cassettes/recent_tracks/page_2.yml
+++ b/spec/support/vcr/cassettes/recent_tracks/page_2.yml
@@ -49,6 +49,7 @@ http_interactions:
             "track": [
               {
                 "artist": { "#text": "TEST_ARTIST_1" },
+                "date": { "uts": "1_479_316_792" },
                 "name": "TEST_TRACK_1"
               }
             ]

--- a/spec/support/vcr/cassettes/recent_tracks/same.yml
+++ b/spec/support/vcr/cassettes/recent_tracks/same.yml
@@ -49,10 +49,12 @@ http_interactions:
             "track": [
               {
                 "artist": { "#text": "TEST_ARTIST" },
+                "date": { "uts": "1_479_316_791" },
                 "name": "TEST_TRACK"
               },
               {
                 "artist": { "#text": "TEST_ARTIST" },
+                "date": { "uts": "1_479_316_792" },
                 "name": "TEST_TRACK"
               }
             ]


### PR DESCRIPTION
We were not filtering out identical tracks with the same timestamp. This was causing play counts to not be accurate. Add filtering of duplicate tracks to keep the play count correct.