### PR TITLE
Add CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/lastfm
+    docker:
+      - image: circleci/ruby:2.6.1
+    steps:
+      - checkout
+
+      - run:
+          name: Bundle install
+          command: bundle install
+
+      - run:
+          name: Run RSpec in parallel
+          command: |
+            bundle exec rspec --profile 10 \
+                              --format RspecJunitFormatter \
+                              --out test_results/rspec.xml \
+                              --format progress
+
+      - store_test_results:
+          path: test_results

--- a/lastfm.gemspec
+++ b/lastfm.gemspec
@@ -34,6 +34,7 @@ listening to over an "unusual" time period.
   s.add_dependency 'rake'
 
   s.add_development_dependency 'rspec', '~> 3.2'
+  s.add_development_dependency "rspec_junit_formatter"
   s.add_development_dependency "vcr"
   s.add_development_dependency "webmock"
 end


### PR DESCRIPTION
We had not defined a CircleCI configuration for the gem. CircleCI was not running whenever we opened a pull request. Added a CircleCI configuration to ensure we run a CI build whenever we raise a pull request.