### PR TITLE
Add filtering of "Now Playing" tracks

### DIFF
--- a/lib/lastfm/adapter.rb
+++ b/lib/lastfm/adapter.rb
@@ -10,7 +10,13 @@ module Lastfm
     end
 
     def tracks
-      track.map { |track_data| Track.new(track_data) }
+      track.reduce([]) do |memo, track_data|
+        if track_data.fetch("@attr", {}).fetch("nowplaying", false)
+          memo
+        else
+          memo << Track.new(track_data)
+        end
+      end
     end
 
     private

--- a/spec/features/get_top_tracks_spec.rb
+++ b/spec/features/get_top_tracks_spec.rb
@@ -121,4 +121,24 @@ RSpec.describe "Get Top Tracks" do
       end
     end
   end
+
+  context "when there is a track playing" do
+    it "only shows played tracks" do
+      VCR.use_cassette("recent_tracks/now_playing") do
+        chart = Lastfm::Chart.new(
+          from: Time.at(1_479_316_791),
+          to: Time.at(1_479_316_791),
+          user: "TEST_USER",
+        )
+
+        entries = chart.get
+
+        entry = entries.first
+        expect(entries.count).to eq 1
+        expect(entry.track_name).to eq "TEST_TRACK"
+        expect(entry.artist_name).to eq "TEST_ARTIST"
+        expect(entry.play_count).to eq 1
+      end
+    end
+  end
 end

--- a/spec/support/vcr/cassettes/recent_tracks/now_playing.yml
+++ b/spec/support/vcr/cassettes/recent_tracks/now_playing.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://ws.audioscrobbler.com/2.0/?api_key=TEST_API_KEY&format=json&from=1479316791&limit=200&method=user.getrecenttracks&page=1&to=1479316791&user=TEST_USER
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.10.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - openresty/1.9.7.3
+      Date:
+      - Tue, 15 Nov 2016 14:52:54 GMT
+      Content-Type:
+      - application/json
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
+      Access-Control-Allow-Methods:
+      - POST, GET, OPTIONS
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Max-Age:
+      - '86400'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "recenttracks": {
+            "@attr": {
+              "page": "1",
+              "perPage": "2",
+              "total": "2",
+              "totalPages": "1",
+              "user": "TEST_USER"
+            },
+            "track": [
+              {
+                "artist": { "#text": "TEST_NOW_PLAYING_ARTIST" },
+                "@attr": { "nowplaying": "true" },
+                "name": "TEST_NOW_PLAYING_TRACK"
+              },
+              {
+                "artist": { "#text": "TEST_ARTIST" },
+                "date": { "uts": "1_479_316_791" },
+                "name": "TEST_TRACK"
+              }
+            ]
+          }
+        }
+    http_version: 
+  recorded_at: Tue, 15 Nov 2016 14:52:55 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
The feed from Last.fm includes the track now playing. This track appears on every page of the feed. We also don't care about the track now playing. Added a filter to the adapter to remove the track now playing.