### PR TITLE
✨ Add a track builder

### DIFF
--- a/lib/lastfm/track.rb
+++ b/lib/lastfm/track.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 module Lastfm
   class Track
+    def self.build(artist_name:, track_name:)
+      new(
+        "artist" => {"#text" => artist_name},
+        "name" => track_name
+      )
+    end
+
     def initialize(data)
       @data = data
     end

--- a/spec/lastfm/connection_spec.rb
+++ b/spec/lastfm/connection_spec.rb
@@ -19,9 +19,9 @@ module Lastfm
 
           expect(recent_tracks).to have_attributes(
             tracks: [
-              Track.new(
-                "artist" => {"#text" => "TEST_ARTIST"},
-                "name" => "TEST_TRACK"
+              Track.build(
+                artist_name: "TEST_ARTIST",
+                track_name: "TEST_TRACK"
               )
             ],
             total_pages: 1

--- a/spec/lastfm/track_spec.rb
+++ b/spec/lastfm/track_spec.rb
@@ -3,6 +3,20 @@ require "spec_helper"
 
 module Lastfm
   RSpec.describe Track do
+    describe ".build" do
+      it "provides a simple way to build a track" do
+        track = Track.build(
+          artist_name: "TEST_ARTIST",
+          track_name: "TEST_TRACK"
+        )
+
+        expect(track).to eq Track.new(
+          "artist" => {"#text" => "TEST_ARTIST"},
+          "name" => "TEST_TRACK"
+        )
+      end
+    end
+
     describe "#artist_name" do
       it "is 'TEST_ARTIST'" do
         artist_name = "TEST_ARTIST"


### PR DESCRIPTION
Before, if you wanted to build a track, you had to know the internals of the data structure. This created too strong of a relationship between the class and its caller. We added a track builder to add an abstraction and loosen the bond between objects.
