### PR TITLE
✨ Add equality to the adapter

### DIFF
--- a/lib/lastfm/adapter.rb
+++ b/lib/lastfm/adapter.rb
@@ -5,6 +5,10 @@ module Lastfm
       @data = data
     end
 
+    def ==(other)
+      tracks == other.tracks && total_pages == other.total_pages
+    end
+
     def total_pages
       attributes.fetch("totalPages").to_i
     end

--- a/spec/lastfm/adapter_spec.rb
+++ b/spec/lastfm/adapter_spec.rb
@@ -3,6 +3,35 @@ require "spec_helper"
 
 module Lastfm
   RSpec.describe Adapter do
+    describe "#==" do
+      context "when the tracks and total pages are the same" do
+        it "is equal" do
+          adapter = build_adapter
+          same = build_adapter
+
+          expect(adapter).to eq same
+        end
+      end
+
+      context "when the track is different" do
+        it "is not equal" do
+          adapter = build_adapter(tracks: [build_track(track_name: "TRACK")])
+          different = build_adapter(tracks: [build_track(track_name: "OTHER")])
+
+          expect(adapter).not_to eq different
+        end
+      end
+
+      context "when the total pages is different" do
+        it "is not equal" do
+          adapter = build_adapter(total_pages: 1)
+          different = build_adapter(total_pages: 2)
+
+          expect(adapter).not_to eq different
+        end
+      end
+    end
+
     describe "#total_pages" do
       it "returns the total number of pages" do
         total_pages = "0"
@@ -33,6 +62,22 @@ module Lastfm
         expect(track.artist_name).to eq artist_name
         expect(track.name).to eq track_name
       end
+    end
+
+    def build_adapter(tracks: [build_track], total_pages: 1)
+      Adapter.new(
+        "recenttracks" => {
+          "track" => tracks,
+          "@attr" => {"totalPages" => total_pages.to_s}
+        }
+      )
+    end
+
+    def build_track(artist_name: "TEST_ARTIST", track_name: "TEST_TRACK")
+      {
+        "artist" => {"#text" => artist_name},
+        "name" => track_name
+      }
     end
   end
 end

--- a/spec/lastfm/connection_spec.rb
+++ b/spec/lastfm/connection_spec.rb
@@ -17,14 +17,16 @@ module Lastfm
 
           recent_tracks = connection.get
 
-          expect(recent_tracks).to have_attributes(
-            tracks: [
-              Track.build(
-                artist_name: "TEST_ARTIST",
-                track_name: "TEST_TRACK"
-              )
-            ],
-            total_pages: 1
+          expect(recent_tracks).to eq Adapter.new(
+            "recenttracks" => {
+              "track" => [
+                {
+                  "artist" => {"#text" => "TEST_ARTIST"},
+                  "name" => "TEST_TRACK"
+                }
+              ],
+              "@attr" => {"totalPages" => "1"}
+            }
           )
         end
       end


### PR DESCRIPTION
Before, we compared adapters by looking at their attributes. This caused objects to know too much about each other. We [added equality][] to the adapter to reduce this connascence.

[added equality]: https://thoughtbot.com/blog/value-object-semantics-in-ruby
