### PR TITLE
✨ Add an adapter builder

### DIFF
--- a/lib/lastfm/adapter.rb
+++ b/lib/lastfm/adapter.rb
@@ -1,6 +1,20 @@
 # frozen_string_literal: true
 module Lastfm
   class Adapter
+    def self.build(tracks:, total_pages:)
+      new(
+        "recenttracks" => {
+          "track" => tracks.map do |track|
+            {
+              "artist" => {"#text" => track[:artist_name]},
+              "name" => track[:track_name]
+            }
+          end,
+          "@attr" => {"totalPages" => total_pages.to_s}
+        }
+      )
+    end
+
     def initialize(data)
       @data = data
     end

--- a/spec/lastfm/adapter_spec.rb
+++ b/spec/lastfm/adapter_spec.rb
@@ -3,6 +3,32 @@ require "spec_helper"
 
 module Lastfm
   RSpec.describe Adapter do
+    describe ".build" do
+      it "provides a simple way to build a adapter" do
+        adapter = Adapter.build(
+          tracks: [
+            {
+              artist_name: "TEST_ARTIST",
+              track_name: "TEST_TRACK"
+            }
+          ],
+          total_pages: "1"
+        )
+
+        expect(adapter).to eq Adapter.new(
+          "recenttracks" => {
+            "track" => [
+              {
+                "artist" => {"#text" => "TEST_ARTIST"},
+                "name" => "TEST_TRACK"
+              }
+            ],
+            "@attr" => {"totalPages" => "1"}
+          }
+        )
+      end
+    end
+
     describe "#==" do
       context "when the tracks and total pages are the same" do
         it "is equal" do

--- a/spec/lastfm/connection_spec.rb
+++ b/spec/lastfm/connection_spec.rb
@@ -17,16 +17,14 @@ module Lastfm
 
           recent_tracks = connection.get
 
-          expect(recent_tracks).to eq Adapter.new(
-            "recenttracks" => {
-              "track" => [
-                {
-                  "artist" => {"#text" => "TEST_ARTIST"},
-                  "name" => "TEST_TRACK"
-                }
-              ],
-              "@attr" => {"totalPages" => "1"}
-            }
+          expect(recent_tracks).to eq Adapter.build(
+            tracks: [
+              {
+                artist_name: "TEST_ARTIST",
+                track_name: "TEST_TRACK"
+              }
+            ],
+            total_pages: 1
           )
         end
       end


### PR DESCRIPTION
Before, if you wanted to build an adapter, you had to know the internals of the data structure. This created too strong of a relationship between the class and its caller. We added an adapter builder to add an abstraction and loosen the bond between objects.
