### PR TITLE
♻️ Refactor the connection initialiser

### DIFF
--- a/lib/lastfm/chart.rb
+++ b/lib/lastfm/chart.rb
@@ -20,12 +20,8 @@ module Lastfm
       @_adapted_response ||= connection.get
     end
 
-    def adapter
-      Adapter
-    end
-
     def connection(page_number = 1)
-      Connection.new(adapter: adapter, page_number: page_number, query: query)
+      Connection.new(page_number: page_number, query: query)
     end
 
     def first_page

--- a/lib/lastfm/connection.rb
+++ b/lib/lastfm/connection.rb
@@ -2,14 +2,13 @@
 
 module Lastfm
   class Connection
-    def initialize(adapter:, page_number: 1, query:)
-      @adapter = adapter
+    def initialize(page_number: 1, query:)
       @page_number = page_number
       @query = query
     end
 
     def get
-      adapter.new(response_body)
+      Adapter.new(response_body)
     end
 
     private

--- a/spec/lastfm/chart_spec.rb
+++ b/spec/lastfm/chart_spec.rb
@@ -17,12 +17,10 @@ module Lastfm
         to = Time.now
         user = "TEST_USER"
         allow(Connection).to receive(:new).once.with(
-          adapter: Adapter,
           page_number: 1,
           query: query
         ).and_return(connection_1)
         allow(Connection).to receive(:new).once.with(
-          adapter: Adapter,
           page_number: 2,
           query: query
         ).and_return(connection_2)

--- a/spec/lastfm/connection_spec.rb
+++ b/spec/lastfm/connection_spec.rb
@@ -8,7 +8,6 @@ module Lastfm
       it "fetches a list of all recently played tracks that match the query" do
         VCR.use_cassette("recent_tracks/one") do
           connection = Connection.new(
-            adapter: Adapter,
             query: Query.new(
               user: "TEST_USER",
               from: Time.new(2016, 11, 16, 17, 19, 51).to_i,


### PR DESCRIPTION
Before, we were passing the adapter into the connection initialiser. This was unnecessary complexity and added no benefit to the implementation. We refactored the connection initialiser to no longer allow us to pass in an adapter.
