### PR TITLE
✨ Add a `Connection#recent_tracks` method

### DIFF
--- a/lib/lastfm/chart.rb
+++ b/lib/lastfm/chart.rb
@@ -17,7 +17,7 @@ module Lastfm
     attr_reader :from, :to, :user
 
     def adapted_response
-      @_adapted_response ||= connection.get
+      @_adapted_response ||= connection.recent_tracks(from..to)
     end
 
     def connection(page_number = 1)
@@ -29,7 +29,9 @@ module Lastfm
     end
 
     def other_pages
-      (2..total_pages).map { |page_number| connection(page_number).get }
+      (2..total_pages).map do |page_number|
+        connection(page_number).recent_tracks(from..to)
+      end
     end
 
     def pages

--- a/lib/lastfm/connection.rb
+++ b/lib/lastfm/connection.rb
@@ -7,8 +7,11 @@ module Lastfm
       @query = query
     end
 
-    def get
-      RecentTrackList.new(response_body)
+    def recent_tracks(period)
+      RecentTrackList.new(response_body(
+        from: period.min.to_i,
+        to: period.max.to_i
+      ))
     end
 
     private
@@ -22,11 +25,7 @@ module Lastfm
       end
     end
 
-    def from
-      query.from
-    end
-
-    def response
+    def response(from:, to:)
       connection.get(
         "/2.0/",
         api_key: ENV["API_KEY"],
@@ -40,12 +39,8 @@ module Lastfm
       )
     end
 
-    def response_body
-      response.body
-    end
-
-    def to
-      query.to
+    def response_body(from:, to:)
+      response(from: from, to: to).body
     end
 
     def user

--- a/spec/lastfm/chart_spec.rb
+++ b/spec/lastfm/chart_spec.rb
@@ -9,17 +9,21 @@ module Lastfm
         chart = []
         from = Time.now
         response_1 = instance_double("RecentTrackList", total_pages: 2)
-        connection_1 = instance_double("Connection", get: response_1)
+        connection_1 = instance_double("Connection")
         response_2 = instance_double("RecentTrackList", total_pages: 2)
-        connection_2 = instance_double("Connection", get: response_2)
+        connection_2 = instance_double("Connection")
         query = instance_double("Query")
         recent_tracks = instance_double("RecentTracks", to_chart: chart)
         to = Time.now
         user = "TEST_USER"
+        allow(connection_1).to receive(:recent_tracks).with(from..to)
+          .and_return(response_1)
         allow(Connection).to receive(:new).once.with(
           page_number: 1,
           query: query
         ).and_return(connection_1)
+        allow(connection_2).to receive(:recent_tracks).with(from..to)
+          .and_return(response_2)
         allow(Connection).to receive(:new).once.with(
           page_number: 2,
           query: query

--- a/spec/lastfm/connection_spec.rb
+++ b/spec/lastfm/connection_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 module Lastfm
   RSpec.describe Connection do
-    describe "#get" do
+    describe "#recent_tracks" do
       it "fetches a list of all recently played tracks that match the query" do
         VCR.use_cassette("recent_tracks/one") do
           connection = Connection.new(
@@ -15,7 +15,9 @@ module Lastfm
             )
           )
 
-          recent_tracks = connection.get
+          from = Time.new(2016, 11, 16, 17, 19, 51)
+          to = Time.new(2016, 11, 16, 17, 19, 51)
+          recent_tracks = connection.recent_tracks(from..to)
 
           expect(recent_tracks).to eq RecentTrackList.build(
             tracks: [


### PR DESCRIPTION
Before, we had a `Connection#get` method that fetched the recent tracks listened to by a user. The method's name failed to describe this functionality. We added a `Connection#recent_tracks` method to better define what is happening.
