### PR TITLE
🗑️ Drop the time range from Query

### DIFF
--- a/lib/lastfm/chart.rb
+++ b/lib/lastfm/chart.rb
@@ -39,7 +39,7 @@ module Lastfm
     end
 
     def query
-      @_query ||= Query.new(from: from, to: to, user: user)
+      @_query ||= Query.new(user: user)
     end
 
     def recent_tracks

--- a/lib/lastfm/query.rb
+++ b/lib/lastfm/query.rb
@@ -4,18 +4,8 @@ module Lastfm
   class Query
     attr_reader :user
 
-    def initialize(from:, to:, user:)
-      @from = from
-      @to = to
+    def initialize(user:)
       @user = user
-    end
-
-    def from
-      @from.to_i
-    end
-
-    def to
-      @to.to_i
     end
   end
 end

--- a/spec/lastfm/chart_spec.rb
+++ b/spec/lastfm/chart_spec.rb
@@ -28,8 +28,7 @@ module Lastfm
           page_number: 2,
           query: query
         ).and_return(connection_2)
-        allow(Query).to receive(:new).once.with(from: from, to: to, user: user)
-          .and_return(query)
+        allow(Query).to receive(:new).once.with(user: user).and_return(query)
         allow(RecentTracks).to receive(:new).once.with(
           [
             response_1,

--- a/spec/lastfm/connection_spec.rb
+++ b/spec/lastfm/connection_spec.rb
@@ -7,13 +7,7 @@ module Lastfm
     describe "#recent_tracks" do
       it "fetches a list of all recently played tracks that match the query" do
         VCR.use_cassette("recent_tracks/one") do
-          connection = Connection.new(
-            query: Query.new(
-              user: "TEST_USER",
-              from: Time.new(2016, 11, 16, 17, 19, 51).to_i,
-              to: Time.new(2016, 11, 16, 17, 19, 51).to_i
-            )
-          )
+          connection = Connection.new(query: Query.new(user: "TEST_USER"))
 
           from = Time.new(2016, 11, 16, 17, 19, 51)
           to = Time.new(2016, 11, 16, 17, 19, 51)

--- a/spec/lastfm/query_spec.rb
+++ b/spec/lastfm/query_spec.rb
@@ -4,33 +4,11 @@ require "spec_helper"
 
 module Lastfm
   RSpec.describe Query do
-    describe "#from" do
-      it "is the initialized from time as a timestamp" do
-        from = Time.now
-        to = Time.now
-        user = "TEST_USER"
-
-        expect(Query.new(from: from, to: to, user: user).from).to eq from.to_i
-      end
-    end
-
-    describe "#to" do
-      it "is the initialized to time as a timestamp" do
-        from = Time.now
-        to = Time.now
-        user = "TEST_USER"
-
-        expect(Query.new(from: from, to: to, user: user).to).to eq to.to_i
-      end
-    end
-
     describe "#user" do
       it "is the initialized user" do
-        from = Time.now
-        to = Time.now
         user = "TEST_USER"
 
-        expect(Query.new(from: from, to: to, user: user).user).to eq user
+        expect(Query.new(user: user).user).to eq user
       end
     end
   end


### PR DESCRIPTION
Before, we changed Connection to use the time range passed to `#get` instead of its initialiser. This rendered the Query time range parameters obsolete. We dropped `#from` and `#to` from Query.
