### PR TITLE
✨ Add page number to `Connection#recent_tracks`

### DIFF
--- a/lib/lastfm/chart.rb
+++ b/lib/lastfm/chart.rb
@@ -30,7 +30,7 @@ module Lastfm
 
     def other_pages
       (2..total_pages).map do |page_number|
-        connection(page_number).recent_tracks(from..to)
+        connection(page_number).recent_tracks(from..to, page_number)
       end
     end
 

--- a/lib/lastfm/connection.rb
+++ b/lib/lastfm/connection.rb
@@ -7,8 +7,9 @@ module Lastfm
       @query = query
     end
 
-    def recent_tracks(period)
+    def recent_tracks(period, page_number = 1)
       RecentTrackList.new(response_body(
+        page: page_number,
         from: period.min.to_i,
         to: period.max.to_i
       ))
@@ -25,7 +26,7 @@ module Lastfm
       end
     end
 
-    def response(from:, to:)
+    def response(page:, from:, to:)
       connection.get(
         "/2.0/",
         api_key: ENV["API_KEY"],
@@ -33,14 +34,14 @@ module Lastfm
         from: from,
         limit: 200,
         method: "user.getrecenttracks",
-        page: page_number,
+        page: page,
         to: to,
         user: user
       )
     end
 
-    def response_body(from:, to:)
-      response(from: from, to: to).body
+    def response_body(page:, from:, to:)
+      response(page: page, from: from, to: to).body
     end
 
     def user

--- a/spec/lastfm/chart_spec.rb
+++ b/spec/lastfm/chart_spec.rb
@@ -22,7 +22,7 @@ module Lastfm
           page_number: 1,
           query: query
         ).and_return(connection_1)
-        allow(connection_2).to receive(:recent_tracks).with(from..to)
+        allow(connection_2).to receive(:recent_tracks).with(from..to, 2)
           .and_return(response_2)
         allow(Connection).to receive(:new).once.with(
           page_number: 2,

--- a/spec/lastfm/connection_spec.rb
+++ b/spec/lastfm/connection_spec.rb
@@ -14,7 +14,7 @@ module Lastfm
 
           from = Time.new(2016, 11, 16, 17, 19, 51)
           to = Time.new(2016, 11, 16, 17, 19, 51)
-          recent_tracks = connection.recent_tracks(from..to)
+          recent_tracks = connection.recent_tracks(from..to, 2)
 
           expect(recent_tracks).to eq RecentTrackList.build(
             tracks: [


### PR DESCRIPTION
Before, we passed the page number to the connection's initialiser. We wanted to move to a point where we wanted to only create one instance for all our API calls. We added a page number option when fetching a user's recent tracks.
