### PR TITLE
🐎 Optimise the creation of connections

### DIFF
--- a/lib/lastfm/chart.rb
+++ b/lib/lastfm/chart.rb
@@ -21,7 +21,7 @@ module Lastfm
     end
 
     def connection(page_number = 1)
-      Connection.new(page_number: page_number, query: query)
+      @connection ||= Connection.new(page_number: page_number, query: query)
     end
 
     def first_page

--- a/spec/lastfm/chart_spec.rb
+++ b/spec/lastfm/chart_spec.rb
@@ -9,25 +9,20 @@ module Lastfm
         chart = []
         from = Time.now
         response_1 = instance_double("RecentTrackList", total_pages: 2)
-        connection_1 = instance_double("Connection")
+        connection = instance_double("Connection")
         response_2 = instance_double("RecentTrackList", total_pages: 2)
-        connection_2 = instance_double("Connection")
         query = instance_double("Query")
         recent_tracks = instance_double("RecentTracks", to_chart: chart)
         to = Time.now
         user = "TEST_USER"
-        allow(connection_1).to receive(:recent_tracks).with(from..to)
+        allow(connection).to receive(:recent_tracks).with(from..to)
           .and_return(response_1)
         allow(Connection).to receive(:new).once.with(
           page_number: 1,
           query: query
-        ).and_return(connection_1)
-        allow(connection_2).to receive(:recent_tracks).with(from..to, 2)
+        ).and_return(connection)
+        allow(connection).to receive(:recent_tracks).with(from..to, 2)
           .and_return(response_2)
-        allow(Connection).to receive(:new).once.with(
-          page_number: 2,
-          query: query
-        ).and_return(connection_2)
         allow(Query).to receive(:new).once.with(user: user).and_return(query)
         allow(RecentTracks).to receive(:new).once.with(
           [


### PR DESCRIPTION
Before, we created a connection whenever we wanted to make an API call. This was unnecessary, and we instantiated more objects than we needed. We optimised the fetching of recent tracks to create only one per execution.
