### PR TITLE
🗑️ Drop the page number from the initialiser

### DIFF
--- a/lib/lastfm/chart.rb
+++ b/lib/lastfm/chart.rb
@@ -20,8 +20,8 @@ module Lastfm
       @_adapted_response ||= connection.recent_tracks(from..to)
     end
 
-    def connection(page_number = 1)
-      @connection ||= Connection.new(page_number: page_number, query: query)
+    def connection
+      @connection ||= Connection.new(query)
     end
 
     def first_page
@@ -30,7 +30,7 @@ module Lastfm
 
     def other_pages
       (2..total_pages).map do |page_number|
-        connection(page_number).recent_tracks(from..to, page_number)
+        connection.recent_tracks(from..to, page_number)
       end
     end
 

--- a/lib/lastfm/connection.rb
+++ b/lib/lastfm/connection.rb
@@ -2,8 +2,7 @@
 
 module Lastfm
   class Connection
-    def initialize(page_number: 1, query:)
-      @page_number = page_number
+    def initialize(query)
       @query = query
     end
 
@@ -17,7 +16,7 @@ module Lastfm
 
     private
 
-    attr_reader :adapter, :page_number, :query
+    attr_reader :adapter, :query
 
     def connection
       Faraday.new(url: "http://ws.audioscrobbler.com") do |faraday|

--- a/spec/lastfm/chart_spec.rb
+++ b/spec/lastfm/chart_spec.rb
@@ -17,10 +17,8 @@ module Lastfm
         user = "TEST_USER"
         allow(connection).to receive(:recent_tracks).with(from..to)
           .and_return(response_1)
-        allow(Connection).to receive(:new).once.with(
-          page_number: 1,
-          query: query
-        ).and_return(connection)
+        allow(Connection).to receive(:new).once.with(query)
+          .and_return(connection)
         allow(connection).to receive(:recent_tracks).with(from..to, 2)
           .and_return(response_2)
         allow(Query).to receive(:new).once.with(user: user).and_return(query)

--- a/spec/lastfm/connection_spec.rb
+++ b/spec/lastfm/connection_spec.rb
@@ -7,10 +7,7 @@ module Lastfm
     describe "#recent_tracks" do
       it "fetches a list of all recently played tracks that match the query" do
         VCR.use_cassette("recent_tracks/page_2") do
-          connection = Connection.new(
-            query: Query.new(user: "TEST_USER"),
-            page_number: 2
-          )
+          connection = Connection.new(Query.new(user: "TEST_USER"))
 
           from = Time.new(2016, 11, 16, 17, 19, 51)
           to = Time.new(2016, 11, 16, 17, 19, 51)
@@ -31,7 +28,7 @@ module Lastfm
       context "when we omit a page number" do
         it "defaults to the first page" do
           VCR.use_cassette("recent_tracks/one") do
-            connection = Connection.new(query: Query.new(user: "TEST_USER"))
+            connection = Connection.new(Query.new(user: "TEST_USER"))
 
             from = Time.new(2016, 11, 16, 17, 19, 51)
             to = Time.new(2016, 11, 16, 17, 19, 51)


### PR DESCRIPTION
Before, we passed the page number when creating connections and fetching recent tracks. The value given to the initialiser was now redundant. We dropped the page number from the initialiser.
