### PR TITLE
🗑️ Drop query from connection

### DIFF
--- a/lib/lastfm/chart.rb
+++ b/lib/lastfm/chart.rb
@@ -21,7 +21,7 @@ module Lastfm
     end
 
     def connection
-      @connection ||= Connection.new(query)
+      @connection ||= Connection.new(user)
     end
 
     def first_page
@@ -36,10 +36,6 @@ module Lastfm
 
     def pages
       [first_page, other_pages].flatten
-    end
-
-    def query
-      @_query ||= Query.new(user: user)
     end
 
     def recent_tracks

--- a/lib/lastfm/connection.rb
+++ b/lib/lastfm/connection.rb
@@ -2,8 +2,8 @@
 
 module Lastfm
   class Connection
-    def initialize(query)
-      @query = query
+    def initialize(username)
+      @username = username
     end
 
     def recent_tracks(period, page_number = 1)
@@ -16,7 +16,7 @@ module Lastfm
 
     private
 
-    attr_reader :adapter, :query
+    attr_reader :adapter
 
     def connection
       Faraday.new(url: "http://ws.audioscrobbler.com") do |faraday|
@@ -35,16 +35,12 @@ module Lastfm
         method: "user.getrecenttracks",
         page: page,
         to: to,
-        user: user
+        user: @username
       )
     end
 
     def response_body(page:, from:, to:)
       response(page: page, from: from, to: to).body
-    end
-
-    def user
-      query.user
     end
   end
 end

--- a/spec/lastfm/chart_spec.rb
+++ b/spec/lastfm/chart_spec.rb
@@ -11,17 +11,15 @@ module Lastfm
         response_1 = instance_double("RecentTrackList", total_pages: 2)
         connection = instance_double("Connection")
         response_2 = instance_double("RecentTrackList", total_pages: 2)
-        query = instance_double("Query")
         recent_tracks = instance_double("RecentTracks", to_chart: chart)
         to = Time.now
         user = "TEST_USER"
         allow(connection).to receive(:recent_tracks).with(from..to)
           .and_return(response_1)
-        allow(Connection).to receive(:new).once.with(query)
+        allow(Connection).to receive(:new).once.with("TEST_USER")
           .and_return(connection)
         allow(connection).to receive(:recent_tracks).with(from..to, 2)
           .and_return(response_2)
-        allow(Query).to receive(:new).once.with(user: user).and_return(query)
         allow(RecentTracks).to receive(:new).once.with(
           [
             response_1,

--- a/spec/lastfm/connection_spec.rb
+++ b/spec/lastfm/connection_spec.rb
@@ -7,7 +7,7 @@ module Lastfm
     describe "#recent_tracks" do
       it "fetches a list of all recently played tracks that match the query" do
         VCR.use_cassette("recent_tracks/page_2") do
-          connection = Connection.new(Query.new(user: "TEST_USER"))
+          connection = Connection.new("TEST_USER")
 
           from = Time.new(2016, 11, 16, 17, 19, 51)
           to = Time.new(2016, 11, 16, 17, 19, 51)
@@ -28,7 +28,7 @@ module Lastfm
       context "when we omit a page number" do
         it "defaults to the first page" do
           VCR.use_cassette("recent_tracks/one") do
-            connection = Connection.new(Query.new(user: "TEST_USER"))
+            connection = Connection.new("TEST_USER")
 
             from = Time.new(2016, 11, 16, 17, 19, 51)
             to = Time.new(2016, 11, 16, 17, 19, 51)


### PR DESCRIPTION
Before, we passed a Query when creating a Connection. This object had only one attribute, `user`, so there was no need to have something wrapping this string. We dropped the query from the connection.
