### PR TITLE
🐛 Fix the `user` argument name

### DIFF
--- a/lib/lastfm/chart.rb
+++ b/lib/lastfm/chart.rb
@@ -2,10 +2,10 @@
 
 module Lastfm
   class Chart
-    def initialize(from:, to:, user:)
+    def initialize(from:, to:, username:)
       @from = from
       @to = to
-      @user = user
+      @username = username
     end
 
     def get
@@ -14,14 +14,14 @@ module Lastfm
 
     private
 
-    attr_reader :from, :to, :user
+    attr_reader :from, :to, :username
 
     def adapted_response
       @_adapted_response ||= connection.recent_tracks(from..to)
     end
 
     def connection
-      @connection ||= Connection.new(user)
+      @connection ||= Connection.new(username)
     end
 
     def first_page

--- a/lib/lastfm/query.rb
+++ b/lib/lastfm/query.rb
@@ -2,10 +2,10 @@
 
 module Lastfm
   class Query
-    attr_reader :user
+    attr_reader :username
 
-    def initialize(user:)
-      @user = user
+    def initialize(username:)
+      @username = username
     end
   end
 end

--- a/spec/features/get_top_tracks_spec.rb
+++ b/spec/features/get_top_tracks_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Get Top Tracks" do
         chart = Lastfm::Chart.new(
           from: Time.at(1_479_316_791),
           to: Time.at(1_479_316_791),
-          user: "TEST_USER"
+          username: "TEST_USER"
         )
 
         expect(chart.get).to be_empty
@@ -23,7 +23,7 @@ RSpec.describe "Get Top Tracks" do
         chart = Lastfm::Chart.new(
           from: Time.at(1_479_316_791),
           to: Time.at(1_479_316_791),
-          user: "TEST_USER"
+          username: "TEST_USER"
         )
         entries = chart.get
         entry = entries.first
@@ -42,7 +42,7 @@ RSpec.describe "Get Top Tracks" do
         chart = Lastfm::Chart.new(
           from: Time.at(1_479_316_791),
           to: Time.at(1_479_316_791),
-          user: "TEST_USER"
+          username: "TEST_USER"
         )
         entries = chart.get
         entry = entries.first
@@ -61,7 +61,7 @@ RSpec.describe "Get Top Tracks" do
         chart = Lastfm::Chart.new(
           from: Time.at(1_479_316_791),
           to: Time.at(1_479_316_791),
-          user: "TEST_USER"
+          username: "TEST_USER"
         )
         entries = chart.get
 
@@ -85,7 +85,7 @@ RSpec.describe "Get Top Tracks" do
           chart = Lastfm::Chart.new(
             from: Time.at(1_479_316_791),
             to: Time.at(1_479_316_791),
-            user: "TEST_USER"
+            username: "TEST_USER"
           )
           entries = chart.get
 
@@ -109,7 +109,7 @@ RSpec.describe "Get Top Tracks" do
         chart = Lastfm::Chart.new(
           from: Time.at(1_479_316_791),
           to: Time.at(1_479_316_791),
-          user: "TEST_USER"
+          username: "TEST_USER"
         )
 
         entries = chart.get
@@ -129,7 +129,7 @@ RSpec.describe "Get Top Tracks" do
         chart = Lastfm::Chart.new(
           from: Time.at(1_479_316_791),
           to: Time.at(1_479_316_791),
-          user: "TEST_USER"
+          username: "TEST_USER"
         )
 
         entries = chart.get

--- a/spec/lastfm/chart_spec.rb
+++ b/spec/lastfm/chart_spec.rb
@@ -13,7 +13,7 @@ module Lastfm
         response_2 = instance_double("RecentTrackList", total_pages: 2)
         recent_tracks = instance_double("RecentTracks", to_chart: chart)
         to = Time.now
-        user = "TEST_USER"
+        username = "TEST_USER"
         allow(connection).to receive(:recent_tracks).with(from..to)
           .and_return(response_1)
         allow(Connection).to receive(:new).once.with("TEST_USER")
@@ -27,7 +27,8 @@ module Lastfm
           ]
         ).and_return(recent_tracks)
 
-        expect(Chart.new(from: from, to: to, user: user).get).to eq chart
+        expect(Chart.new(from: from, to: to, username: username).get)
+          .to eq chart
       end
     end
   end

--- a/spec/lastfm/query_spec.rb
+++ b/spec/lastfm/query_spec.rb
@@ -4,11 +4,11 @@ require "spec_helper"
 
 module Lastfm
   RSpec.describe Query do
-    describe "#user" do
-      it "is the initialized user" do
-        user = "TEST_USER"
+    describe "#username" do
+      it "is the initialized username" do
+        username = "TEST_USER"
 
-        expect(Query.new(user: user).user).to eq user
+        expect(Query.new(username: username).username).to eq username
       end
     end
   end


### PR DESCRIPTION
Before, we passed a user's name using the `user` argument. The name was incorrect because it only represents the name of the user. The old name inferred that it held an entire user entity. We fixed the `user` argument name to better reflect its use.
