### PR TITLE
🐛 Fix the `Connection` class

### DIFF
--- a/lib/lastfm.rb
+++ b/lib/lastfm.rb
@@ -6,13 +6,13 @@ require "faraday_middleware"
 
 require "lastfm/artist"
 require "lastfm/chart"
-require "lastfm/connection"
 require "lastfm/entry"
 require "lastfm/query"
 require "lastfm/recent_track_list"
 require "lastfm/recent_tracks"
 require "lastfm/track"
 require "lastfm/tracks"
+require "lastfm/user"
 require "lastfm/version"
 
 Dotenv.load

--- a/lib/lastfm/chart.rb
+++ b/lib/lastfm/chart.rb
@@ -17,11 +17,11 @@ module Lastfm
     attr_reader :from, :to, :username
 
     def adapted_response
-      @_adapted_response ||= connection.recent_tracks(from..to)
+      @_adapted_response ||= user.recent_tracks(from..to)
     end
 
-    def connection
-      @connection ||= Connection.new(username)
+    def user
+      @user ||= User.new(username)
     end
 
     def first_page
@@ -30,7 +30,7 @@ module Lastfm
 
     def other_pages
       (2..total_pages).map do |page_number|
-        connection.recent_tracks(from..to, page_number)
+        user.recent_tracks(from..to, page_number)
       end
     end
 

--- a/lib/lastfm/user.rb
+++ b/lib/lastfm/user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Lastfm
-  class Connection
+  class User
     def initialize(username)
       @username = username
     end

--- a/spec/lastfm/chart_spec.rb
+++ b/spec/lastfm/chart_spec.rb
@@ -9,16 +9,16 @@ module Lastfm
         chart = []
         from = Time.now
         response_1 = instance_double("RecentTrackList", total_pages: 2)
-        connection = instance_double("Connection")
+        user = instance_double("User")
         response_2 = instance_double("RecentTrackList", total_pages: 2)
         recent_tracks = instance_double("RecentTracks", to_chart: chart)
         to = Time.now
         username = "TEST_USER"
-        allow(connection).to receive(:recent_tracks).with(from..to)
+        allow(user).to receive(:recent_tracks).with(from..to)
           .and_return(response_1)
-        allow(Connection).to receive(:new).once.with("TEST_USER")
-          .and_return(connection)
-        allow(connection).to receive(:recent_tracks).with(from..to, 2)
+        allow(User).to receive(:new).once.with("TEST_USER")
+          .and_return(user)
+        allow(user).to receive(:recent_tracks).with(from..to, 2)
           .and_return(response_2)
         allow(RecentTracks).to receive(:new).once.with(
           [

--- a/spec/lastfm/user_spec.rb
+++ b/spec/lastfm/user_spec.rb
@@ -3,15 +3,15 @@
 require "spec_helper"
 
 module Lastfm
-  RSpec.describe Connection do
+  RSpec.describe User do
     describe "#recent_tracks" do
       it "fetches a list of all recently played tracks that match the query" do
         VCR.use_cassette("recent_tracks/page_2") do
-          connection = Connection.new("TEST_USER")
+          user = User.new("TEST_USER")
 
           from = Time.new(2016, 11, 16, 17, 19, 51)
           to = Time.new(2016, 11, 16, 17, 19, 51)
-          recent_tracks = connection.recent_tracks(from..to, 2)
+          recent_tracks = user.recent_tracks(from..to, 2)
 
           expect(recent_tracks).to eq RecentTrackList.build(
             tracks: [
@@ -28,11 +28,11 @@ module Lastfm
       context "when we omit a page number" do
         it "defaults to the first page" do
           VCR.use_cassette("recent_tracks/one") do
-            connection = Connection.new("TEST_USER")
+            user = User.new("TEST_USER")
 
             from = Time.new(2016, 11, 16, 17, 19, 51)
             to = Time.new(2016, 11, 16, 17, 19, 51)
-            recent_tracks = connection.recent_tracks(from..to)
+            recent_tracks = user.recent_tracks(from..to)
 
             expect(recent_tracks).to eq RecentTrackList.build(
               tracks: [


### PR DESCRIPTION
Before, we had a `Connection` class that fetched information related to a user. It had the wrong name; we should have called it `User`. All its responsibilities were to the user and nothing else. We fixed the `Connection` class by renaming it `User`.
