### PR TITLE
🗑️ Drop the `adapter` attribute reader

### DIFF
--- a/lib/lastfm/user.rb
+++ b/lib/lastfm/user.rb
@@ -16,8 +16,6 @@ module Lastfm
 
     private
 
-    attr_reader :adapter
-
     def connection
       Faraday.new(url: "http://ws.audioscrobbler.com") do |faraday|
         faraday.response :json


### PR DESCRIPTION
Before, we dropped the `@adapter` instance variable but left the attribute reader. The class had no use for the reader and only added unnecessary overhead for developers. We dropped the `adapter` attribute reader.
