### PR TITLE
🔧 Make CircleCI use "next-gen" images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/lastfm
     docker:
-      - image: circleci/ruby:2.6.1
+      - image: cimg/ruby:2.6.1
     steps:
       - checkout
 


### PR DESCRIPTION
Before, we used a [deprecated Docker convenience image][] when building the library. CircleCI was advising us to upgrade to a "next-gen" one. Newer versions of Ruby were also unavailable using the deprecated images. We made CircleCI use the "next-gen" images.

[deprecated docker convenience image]: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034
