### PR TITLE
♻️ Refactor the User constructor

### DIFF
--- a/lib/lastfm/user.rb
+++ b/lib/lastfm/user.rb
@@ -9,9 +9,9 @@ module Lastfm
       limit: 200
     }.freeze
 
-    def initialize(username, connection = build_connection)
+    def initialize(username)
       @username = username
-      @connection = connection
+      @connection = build_connection
     end
 
     def recent_tracks(period, page_number = 1)


### PR DESCRIPTION
Before, the User allowed us to inject a dependency. The level of abstraction needed to be higher. There was no need to inject a Connection. We refactored the User constructor to no longer take this argument.
