### PR TITLE
♻️ Refactor the HTTP Client constructor

### DIFF
--- a/lib/lastfm/http_client.rb
+++ b/lib/lastfm/http_client.rb
@@ -9,8 +9,8 @@ module Lastfm
       limit: 200
     }.freeze
 
-    def initialize
-      @connection = build_connection
+    def initialize(connection = build_connection)
+      @connection = connection
     end
 
     def get(entity, params)


### PR DESCRIPTION
Before, the HTTP Client depended on Faraday, and there was no way to change this. We needed to vary the implementation depending on the circumstances. We refactored the HTTP Client constructor to allow for dependency injection.
