### PR TITLE
✨ Add a stubbed connection

### DIFF
--- a/lib/lastfm/http_client.rb
+++ b/lib/lastfm/http_client.rb
@@ -9,6 +9,10 @@ module Lastfm
       limit: 200
     }.freeze
 
+    def self.null(response_bodies = {})
+      new(StubbedConnection.new(response_bodies))
+    end
+
     def initialize(connection = build_connection)
       @connection = connection
     end
@@ -32,6 +36,25 @@ module Lastfm
 
     def response_body(params)
       response(params).body
+    end
+
+    class StubbedConnection
+      def initialize(response_bodies)
+        @response_bodies = response_bodies
+      end
+
+      def get(url, params)
+        response_body = @response_bodies.fetch(
+          params.except(*BASE_PARAMS.keys),
+          {}
+        )
+
+        StubbedResponse.new(response_body)
+      end
+
+      private
+
+      StubbedResponse = Struct.new(:body)
     end
   end
 end

--- a/spec/lastfm/http_client_spec.rb
+++ b/spec/lastfm/http_client_spec.rb
@@ -38,6 +38,32 @@ module Lastfm
           )
         end
       end
+
+      context "when nulled without a configuration" do
+        it "returns the default response" do
+          http_client = Lastfm::HttpClient.null
+          stub_const("ExampleEntity", example_entity)
+
+          response = http_client.get(ExampleEntity, foo: "bar")
+
+          expect(response).to eq ExampleEntity.new({})
+        end
+      end
+
+      context "when nulled with a configuration" do
+        it "returns the correct response" do
+          response_bodies = {
+            {foo: "bar"} => "TEST_CORRECT_RESPONSE",
+            {baz: "qux"} => "TEST_INCORRECT_RESPONSE"
+          }
+          http_client = Lastfm::HttpClient.null(response_bodies)
+          stub_const("ExampleEntity", example_entity)
+
+          response = http_client.get(ExampleEntity, foo: "bar")
+
+          expect(response).to eq ExampleEntity.new("TEST_CORRECT_RESPONSE")
+        end
+      end
     end
 
     def example_entity


### PR DESCRIPTION
Before, we relied on WebMock and VCR to mock our network requests. This was unnecessary, and we could solve the problem with [Nullables][]. We added a stubbed connection as the first step in this direction.

[nullables]: https://www.jamesshore.com/v2/blog/2018/testing-without-mocks
