### PR TITLE
♻️ Refactor the HTTP Client specs

### DIFF
--- a/spec/lastfm/http_client_spec.rb
+++ b/spec/lastfm/http_client_spec.rb
@@ -6,37 +6,14 @@ module Lastfm
   RSpec.describe HttpClient do
     describe "#get" do
       it "returns the given entity" do
-        VCR.use_cassette("recent_tracks/page_2") do
-          http_client = Lastfm::HttpClient.new
-          stub_const("ExampleEntity", example_entity)
+        response_bodies = {{foo: "bar"} => "TEST_RESPONSE"}
+        connection = Lastfm::HttpClient::StubbedConnection.new(response_bodies)
+        http_client = Lastfm::HttpClient.new(connection)
+        stub_const("ExampleEntity", example_entity)
 
-          response = http_client.get(
-            ExampleEntity,
-            user: "TEST_USER",
-            page: 2,
-            from: 1479316791,
-            to: 1479316791
-          )
+        response = http_client.get(ExampleEntity, foo: "bar")
 
-          expect(response).to eq ExampleEntity.new(
-            "recenttracks" => {
-              "@attr" => {
-                "page" => "2",
-                "perPage" => "2",
-                "total" => "3",
-                "totalPages" => "2",
-                "user" => "TEST_USER"
-              },
-              "track" => [
-                {
-                  "artist" => {"#text" => "TEST_ARTIST_1"},
-                  "date" => {"uts" => "1_479_316_792"},
-                  "name" => "TEST_TRACK_1"
-                }
-              ]
-            }
-          )
-        end
+        expect(response).to eq ExampleEntity.new("TEST_RESPONSE")
       end
 
       context "when nulled without a configuration" do


### PR DESCRIPTION
Before, we were using VCR to mock out the HTTP Client's network calls. Since we added a stubbed connection, it was unnecessary to keep using VCR. We refactored the HTTP Client's specs to use the new embedded stub.
