### PR TITLE
🐛 Fix the nullable HTTP client's default response

### DIFF
--- a/lib/lastfm/http_client.rb
+++ b/lib/lastfm/http_client.rb
@@ -46,7 +46,12 @@ module Lastfm
       def get(url, params)
         response_body = @response_bodies.fetch(
           params.except(*BASE_PARAMS.keys),
-          {}
+          {
+            "recenttracks" => {
+              "track" => [],
+              "@attr" => {"totalPages" => 1}
+            }
+          }
         )
 
         StubbedResponse.new(response_body)

--- a/spec/lastfm/http_client_spec.rb
+++ b/spec/lastfm/http_client_spec.rb
@@ -23,7 +23,12 @@ module Lastfm
 
           response = http_client.get(ExampleEntity, foo: "bar")
 
-          expect(response).to eq ExampleEntity.new({})
+          expect(response).to eq ExampleEntity.new(
+            "recenttracks" => {
+              "track" => [],
+              "@attr" => {"totalPages" => 1}
+            }
+          )
         end
       end
 


### PR DESCRIPTION
Before, the nullable HTTP client returned an empty hash as its default response. This was inaccurate and was different to the real world. We fixed the nullable HTTP client's default response to match the API.
