### PR TITLE
♻️ Refactor the nullable HTTP Client

### DIFF
--- a/lib/lastfm/http_client.rb
+++ b/lib/lastfm/http_client.rb
@@ -10,7 +10,7 @@ module Lastfm
     }.freeze
 
     def self.null(response_bodies = {})
-      new(StubbedConnection.new(response_bodies))
+      new(StubbedConnection.new(response_bodies.transform_values(&:to_h)))
     end
 
     def initialize(connection = build_connection)

--- a/spec/lastfm/http_client_spec.rb
+++ b/spec/lastfm/http_client_spec.rb
@@ -34,16 +34,16 @@ module Lastfm
 
       context "when nulled with a configuration" do
         it "returns the correct response" do
+          stub_const("ExampleEntity", example_entity)
           response_bodies = {
-            {foo: "bar"} => "TEST_CORRECT_RESPONSE",
-            {baz: "qux"} => "TEST_INCORRECT_RESPONSE"
+            {foo: "bar"} => ExampleEntity.new("data" => "correct"),
+            {baz: "qux"} => ExampleEntity.new("data" => "incorrect")
           }
           http_client = Lastfm::HttpClient.null(response_bodies)
-          stub_const("ExampleEntity", example_entity)
 
           response = http_client.get(ExampleEntity, foo: "bar")
 
-          expect(response).to eq ExampleEntity.new("TEST_CORRECT_RESPONSE")
+          expect(response).to eq ExampleEntity.new("data" => "correct")
         end
       end
     end
@@ -58,6 +58,10 @@ module Lastfm
 
         def ==(other)
           response_body == other.response_body
+        end
+
+        def to_h
+          response_body
         end
       end
     end


### PR DESCRIPTION
Before, the signature for creating a nullable HTTP Client was very complex. Developers needed to understand and know about the underlying response structure. We refactored the nullable HTTP Client to make this structure more abstract.