### PR TITLE
✨ Add a hash representation of the Recent Track List

### DIFF
--- a/lib/lastfm/recent_track_list.rb
+++ b/lib/lastfm/recent_track_list.rb
@@ -24,6 +24,10 @@ module Lastfm
       tracks == other.tracks && total_pages == other.total_pages
     end
 
+    def to_h
+      @data
+    end
+
     def total_pages
       attributes.fetch("totalPages").to_i
     end

--- a/spec/lastfm/recent_track_list_spec.rb
+++ b/spec/lastfm/recent_track_list_spec.rb
@@ -61,6 +61,34 @@ module Lastfm
       end
     end
 
+    describe "#to_h" do
+      it "returns a hash representation of the instance" do
+        recent_track_list = RecentTrackList.build(
+          tracks: [
+            {
+              artist_name: "TEST_ARTIST",
+              track_name: "TEST_TRACK"
+            }
+          ],
+          total_pages: "1"
+        )
+
+        to_h = recent_track_list.to_h
+
+        expect(to_h).to eq(
+          "recenttracks" => {
+            "track" => [
+              {
+                "artist" => {"#text" => "TEST_ARTIST"},
+                "name" => "TEST_TRACK"
+              }
+            ],
+            "@attr" => {"totalPages" => "1"}
+          }
+        )
+      end
+    end
+
     describe "#total_pages" do
       it "returns the total number of pages" do
         total_pages = "0"


### PR DESCRIPTION
Before, there was no way to get structured data out of the Recent Track List. It was challenging to reuse the instance's data in our test environment. We added a hash representation of the Recent Track List to resolve this issue.
