### PR TITLE
✨ Add a nullable User

### DIFF
--- a/lib/lastfm/user.rb
+++ b/lib/lastfm/user.rb
@@ -2,6 +2,19 @@
 
 module Lastfm
   class User
+    def self.null(username, recent_track_lists = {})
+      response_bodies = recent_track_lists.transform_keys do |key|
+        {
+          user: username,
+          page: key.fetch(:page_number, 1),
+          from: key[:period].min.to_i,
+          to: key[:period].max.to_i
+        }
+      end
+
+      new(username, HttpClient.null(response_bodies))
+    end
+
     def initialize(username, http_client = HttpClient.new)
       @username = username
       @http_client = http_client

--- a/spec/lastfm/user_spec.rb
+++ b/spec/lastfm/user_spec.rb
@@ -46,6 +46,52 @@ module Lastfm
           end
         end
       end
+
+      context "when nulled without a configuration" do
+        it "returns the default recent track list" do
+          user = User.null("TEST_USER")
+
+          from = Time.new(2016, 11, 16, 17, 19, 51)
+          to = Time.new(2016, 11, 16, 17, 19, 51)
+          recent_tracks = user.recent_tracks(from..to)
+
+          expect(recent_tracks).to eq RecentTrackList.build(
+            tracks: [],
+            total_pages: 1
+          )
+        end
+      end
+
+      context "when nulled with a configuration" do
+        it "returns the correct response" do
+          from = Time.new(2016, 11, 16, 17, 19, 51)
+          to = Time.new(2016, 11, 16, 17, 19, 51)
+          recent_track_lists = {
+            {period: (from..to)} => RecentTrackList.build(
+              tracks: [
+                {
+                  artist_name: "TEST_ARTIST",
+                  track_name: "TEST_TRACK"
+                }
+              ],
+              total_pages: 1
+            )
+          }
+          user = User.null("TEST_USER", recent_track_lists)
+
+          recent_tracks = user.recent_tracks(from..to)
+
+          expect(recent_tracks).to eq RecentTrackList.build(
+            tracks: [
+              {
+                artist_name: "TEST_ARTIST",
+                track_name: "TEST_TRACK"
+              }
+            ],
+            total_pages: 1
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Before, we had to know about the underlying data structure to stub out a network connection. This was unnecessary at this level of abstraction. We added a nullable User to make testing easier.
